### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -26,3 +26,5 @@ VERSION eol=lf
 *.{jpg} binary
 *.{ico} binary
 *.{bmp} binary
+
+tsconfig.*.json linguist-language=JSON-with-Comments


### PR DESCRIPTION
fix the ugly red text on GitHub for JSONC (JSON with comments) files